### PR TITLE
Quote marker starts with "#"

### DIFF
--- a/rpp/encoder.py
+++ b/rpp/encoder.py
@@ -53,7 +53,7 @@ def quote_string(value, quote_pipe=True):
 
 
 def should_quote(s, quote_pipe):
-    return (quote_pipe or not starts_with_pipe(s)) and (starts_with_quote(s) or has_whitespace(s))
+    return (quote_pipe or not starts_with_pipe(s)) and (starts_with_quote(s) or has_whitespace(s)) or s.startswith('#')
 
 
 def has_whitespace(s):


### PR DESCRIPTION
We should Quote marker starts with "#". Without quotation mark, REAPER will discard the marker:
![image](https://github.com/user-attachments/assets/7a8218be-9d8c-4bb8-a1c1-1eeddb29f5b8)
![image](https://github.com/user-attachments/assets/b245b856-721a-4085-b84d-40bce27636ff)
Quotation mark can fix this:
![image](https://github.com/user-attachments/assets/13928250-bafa-46bd-84a2-bed32076009a)
![image](https://github.com/user-attachments/assets/ce7f620a-494c-45d9-99ab-c35faeef2eac)
